### PR TITLE
Add a --pull option when building from Dockerfile.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/dockerslaves/DockerDriver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/dockerslaves/DockerDriver.java
@@ -272,9 +272,16 @@ public class DockerDriver implements Closeable {
                 .stdout(launcher.getListener().getLogger()).join() == 0;
     }
 
-    public int buildDockerfile(Launcher launcher, String dockerfilePath, String tag)  throws IOException, InterruptedException {
+    public int buildDockerfile(Launcher launcher, String dockerfilePath, String tag, boolean pull)  throws IOException, InterruptedException {
+        String pullOption = "--pull=";
+        if (pull) {
+            pullOption += "true";
+        } else {
+            pullOption += "false";
+        }
         ArgumentListBuilder args = new ArgumentListBuilder()
                 .add("build")
+                .add(pullOption)
                 .add("-t", tag)
                 .add(dockerfilePath);
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/dockerslaves/DockerfileContainerDefinition.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/dockerslaves/DockerfileContainerDefinition.java
@@ -49,12 +49,15 @@ public class DockerfileContainerDefinition extends ContainerDefinition {
 
     private final String contextPath;
 
+    private final boolean forcePull;
+
     private transient String image;
 
     @DataBoundConstructor
-    public DockerfileContainerDefinition(String contextPath, String dockerfile) {
+    public DockerfileContainerDefinition(String contextPath, String dockerfile, boolean forcePull) {
         this.contextPath = contextPath;
         this.dockerfile = dockerfile;
+        this.forcePull = forcePull;
     }
 
     public String getDockerfile() {
@@ -67,6 +70,7 @@ public class DockerfileContainerDefinition extends ContainerDefinition {
 
     @Override
     public String getImage(DockerDriver driver, Launcher.ProcStarter procStarter, TaskListener listener) throws IOException, InterruptedException {
+        boolean pull = forcePull;
         if (image != null) return image;
         String tag = Long.toHexString(System.nanoTime());
 
@@ -88,7 +92,7 @@ public class DockerfileContainerDefinition extends ContainerDefinition {
         pathToDockerfile.copyTo(new FilePath(new File(context, "Dockerfile")));
 
         final Launcher launcher = new Launcher.LocalLauncher(listener);
-        if (driver.buildDockerfile(launcher, context.getAbsolutePath(), tag) != 0) {
+        if (driver.buildDockerfile(launcher, context.getAbsolutePath(), tag, pull) != 0) {
             throw new IOException("Failed to build image from Dockerfile "+dockerfile);
         }
         Util.deleteRecursive(context);

--- a/src/main/resources/com/cloudbees/jenkins/plugins/dockerslaves/DockerfileContainerDefinition/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/dockerslaves/DockerfileContainerDefinition/config.jelly
@@ -32,6 +32,9 @@
   <f:entry title="Context Path" field="contextPath">
     <f:textbox />
   </f:entry>
+  <f:entry title="Force pull" field="forcePull">
+    <f:checkbox/>
+  </f:entry>
 
 </j:jelly>
 


### PR DESCRIPTION
This option is available when building from an image.
We also need it when building from Dockerfile, to
ensure the base images are up to date.